### PR TITLE
👷 Update multiple builds process of a document to single

### DIFF
--- a/locale/update.sh
+++ b/locale/update.sh
@@ -10,8 +10,6 @@ set -ex
 # pull po files from transifex
 cd `dirname $0`
 #rm -R pot  # skip this line cause "already unused pot files will not removed" but we must keep these files to avoid commit for only "POT-Creation-Time" line updated. see: https://github.com/sphinx-doc/sphinx/issues/3443
-sphinx-build -T -b gettext ../pyvista/doc/source pot || true  # will fail on VTK9
-sphinx-build -T -b gettext ../pyvista/doc/source pot || true  # need it again due to all our docstring examples
 sphinx-build -T -b gettext ../pyvista/doc/source pot
 sphinx-intl update-txconfig-resources -p pot -d .
 cat .tx/config


### PR DESCRIPTION
Subject: 👷 Update multiple builds process of a document to single

### Feature or Bugfix
<!-- please choose -->
- Maintenance

### Purpose
- Multiple builds process of a document is no longer needed.

### Detail
- None

### Relates
- None
